### PR TITLE
Update django from 1.11.8 to 2.0

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -6,7 +6,7 @@ wheel==0.30.0
 
 
 # Conservative Django
-django==1.11.8 # pyup: <2.0
+django==2.0 # pyup: <2.0
 
 # Configuration
 django-environ==0.4.4

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/models.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/models.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import AbstractUser
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_urls.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse, resolve
+from django.urls import reverse, resolve
 
 from test_plus.test import TestCase
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 
 from . import views
 
+app_name = 'users'
 urlpatterns = [
     url(
         regex=r'^$',

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.views.generic import DetailView, ListView, RedirectView, UpdateView
 
 from django.contrib.auth.mixins import LoginRequiredMixin


### PR DESCRIPTION
- Refactor django.core.urlresolvers module import to django.urls. Resolves: The django.core.urlresolvers module is removed in favor of its new location, django.urls.

- Add an app namespace to urls in user app. Resolves: Support for setting a URL instance namespace without an application namespace is removed.